### PR TITLE
Add filePath to allow config URL to remote file systems.

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -26,6 +26,15 @@ class Module extends \yii\base\Module
      */
     public $grapesJsVariables = [];
 
+    /**
+     * Upload path.
+     * If you use AWS as file system, is the AWS S3 bucket URL
+     *
+     * @author lribeiro <luis.mribeiro@sapo.pt>
+     * @var string
+     */
+    public $filesPath = '/files/';
+
     public function init()
     {
         \Yii::$app->request->parsers['application/json'] = JsonParser::class;

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ And add module in your config `modules`
 'modules' => [
     'grapesjs' => [
         'class' => \thecodeholic\yii2grapesjs\Module::class,
+        'filesPath' => '/files/'
         // custom placeholder variables which will be added into richtext
         // default is empty array
         'grapesJsVariables' => [
@@ -51,7 +52,7 @@ And add module in your config `modules`
 
 Configuring AssetManager
 ------------------------
-The package uses `Yii::$app->fs` so you need to configure `fs` component to be one of the available 
+The package uses `Yii::$app->fs` so you need to configure `fs` component to be one of the available
 targets of `creocoder\flysystem`
 
 Checkout its documentation if you want to specify different targets
@@ -146,4 +147,3 @@ public function actions()
     ]);
 }
 ```
-

--- a/actions/UploadAction.php
+++ b/actions/UploadAction.php
@@ -20,6 +20,13 @@ use yii\web\UploadedFile;
  */
 class UploadAction extends BaseAction
 {
+    public $filesPath;
+
+    public function init()
+    {
+        $this->filesPath = Yii::$app->getModule('grapesjs')->filesPath;
+    }
+
     public function run()
     {
         Yii::$app->response->format = Response::FORMAT_JSON;
@@ -30,9 +37,11 @@ class UploadAction extends BaseAction
         $files = UploadedFile::getInstancesByName('files');
         foreach ($files as $file) {
             $stream = fopen($file->tempName, 'r+');
-            Yii::$app->fs->writeStream($file->name, $stream);
-            $response[] = '/files/' . $file->name;
+            $filename = Yii::$app->security->generateRandomString(16) . '.' . $file->extension;
+            Yii::$app->fs->writeStream($filename, $stream);
+            $response[] = $this->filesPath . $filename;
         }
+
         return [
             'data' => $response
         ];


### PR DESCRIPTION
Using AWS as the file system the upload action returns the wrong path to the file.
Example: `{"data": ["/files/example.png"]}`

With this new variable, we can configure the bucket URL and the response will be a complete useful URL.
Example: `{"data":["https://ams1.aws.com/mybucket-public/example.png"]}`

I also renamed the filename to prevent errors for existing file names.
Example
```
{
    "name": "Exception",
    "message": "File already exists at path: example.png",
    "code": 0,
    "type": "League\\Flysystem\\FileExistsException",
     ...
}